### PR TITLE
removed in-handler execution of URL replacement

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,79 +2,108 @@
 
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:f714fa0ab4449a2fe13d156446ac1c1e16bc85334e9be320d42bf8bee362ba45"
   name = "github.com/eapache/go-resiliency"
   packages = ["breaker"]
+  pruneopts = ""
   revision = "6800482f2c813e689c88b7ed3282262385011890"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:1f7503fa58a852a1416556ae2ddb219b49a1304fd408391948e2e3676514c48d"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
+  pruneopts = ""
   revision = "bb955e01b9346ac19dc29eb16586c90ded99a98c"
 
 [[projects]]
+  digest = "1:c05dc14dd75a9697b8410ea13445ceb40669448f789afe955351ad34bc998cd0"
   name = "github.com/eapache/queue"
   packages = ["."]
+  pruneopts = ""
   revision = "ded5959c0d4e360646dc9e9908cff48666781367"
   version = "v1.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:09307dfb1aa3f49a2bf869dcfa4c6c06ecd3c207221bd1c1a1141f0e51f209eb"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = ""
   revision = "553a641470496b2327abcac10b36396bd98e45c9"
 
 [[projects]]
   branch = "master"
+  digest = "1:98fd9594fd8d22c4433e391e60fb4aa3f093c47ff086963d9da8ea61f54368e7"
   name = "github.com/justsocialapps/assert"
   packages = ["."]
+  pruneopts = ""
   revision = "c78644921ea5d4935e7949245e13d6e770b029fb"
 
 [[projects]]
   branch = "master"
+  digest = "1:abf4d042b7040bfa860e4450b644e8d8bff6232f3d6bd54b4473c372224511dc"
   name = "github.com/justsocialapps/justlib"
   packages = ["."]
+  pruneopts = ""
   revision = "a08866ee7c386d23a843971fed36a4ae211a55a5"
 
 [[projects]]
+  digest = "1:d5cb4f9f5ec0229cb1b19e935d1f929058e8186fdc5f5b84f54515ac89fe20e3"
   name = "github.com/mssola/user_agent"
   packages = ["."]
+  pruneopts = ""
   revision = "07efe2b857fb8c02d2dd85c12d0145f58554ec7c"
 
 [[projects]]
+  digest = "1:c1371437c263e0cf8534a3de094d3406de9eafedf6283de9bc0916c7b93642a1"
   name = "github.com/pierrec/lz4"
   packages = ["."]
+  pruneopts = ""
   revision = "5c9560bfa9ace2bf86080bf40d46b34ae44604df"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:ff95a6c61f34f32e57833783059c80274d84e9c74e6e315c3dc2e93e9bf3dab9"
   name = "github.com/pierrec/xxHash"
   packages = ["xxHash32"]
+  pruneopts = ""
   revision = "f051bb7f1d1aaf1b5a665d74fb6b0217712c69f7"
   version = "v0.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:5e3f4c2357e1e95ede9f36dc027b4b5a2cca463c8899344c22ebeb7c0abab8d5"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
+  pruneopts = ""
   revision = "1f30fe9094a513ce4c700b9a54458bbb0c96996c"
 
 [[projects]]
+  digest = "1:28a597ed5b4e157d58e2f59b0a013dd662d7220024e193ba8ad3dacedf738efe"
   name = "gopkg.in/Shopify/sarama.v1"
   packages = ["."]
+  pruneopts = ""
   revision = "c01858abb625b73a3af51d0798e4ad42c8147093"
   version = "v1.12.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9cdd881f51e4e0bc67081e1a9bb419367af1733be34c39245704b07b27b0effa"
+  input-imports = [
+    "github.com/justsocialapps/assert",
+    "github.com/justsocialapps/justlib",
+    "github.com/mssola/user_agent",
+    "gopkg.in/Shopify/sarama.v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -1,6 +1,8 @@
 package analytics
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"log"
 	"net/http"
 	"strings"
@@ -8,16 +10,34 @@ import (
 	"github.com/justsocialapps/holmes/assets"
 )
 
+var analyticsRes []byte
+var etag string
+
 // Analytics returns an HTTP handler function that delivers the tracking client
 // library.
-func Analytics(baseURL string) http.HandlerFunc {
-	res := strings.Replace(assets.Analyticsjs, "__HOLMES_BASE_URL__", baseURL, -1)
+func Analytics(w http.ResponseWriter, r *http.Request) {
+	if analyticsRes == nil || len(analyticsRes) == 0 {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
 
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Type", "application/javascript")
-		_, err := w.Write([]byte(res))
-		if err != nil {
-			log.Printf("Error sending analytics script: %s\n", err)
-		}
+	if match := r.Header.Get("If-None-Match"); match == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/javascript")
+	w.Header().Set("Etag", etag)
+
+	if _, err := w.Write(analyticsRes); err != nil {
+		log.Printf("Error sending analytics script: %s\n", err)
+	}
+}
+
+func PrepareAnalytics(baseURL string) {
+	if len(baseURL) != 0 && (analyticsRes == nil || len(analyticsRes) == 0) {
+		analyticsRes = []byte(strings.Replace(assets.Analyticsjs, "__HOLMES_BASE_URL__", baseURL, -1))
+		hash := sha256.Sum256(analyticsRes)
+		etag = hex.EncodeToString(hash[:32])
 	}
 }

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -9,15 +9,31 @@ import (
 	"github.com/justsocialapps/holmes/assets"
 )
 
-func TestAnalytics(t *testing.T) {
+func TestAnalyticsWithoutSetValue(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	request, _ := http.NewRequest("GET", "", nil)
 	assets.Analyticsjs = "base url: __HOLMES_BASE_URL__"
-	assert := assert.NewAssert(t)
+	assertion := assert.NewAssert(t)
 
-	Analytics("https://example.org/baseurl")(recorder, request)
+	Analytics(recorder, request)
 
-	assert.Equal(recorder.Header().Get("Content-Type"), "application/javascript", "wrong content type")
-	assert.Equal(recorder.Code, http.StatusOK, "wrong status code")
-	assert.Match("base url: https://example.org/baseurl", recorder.Body.String(), "wrong body")
+	assertion.Equal(len(recorder.Header()), 0, "wrong content type")
+	assertion.Equal(recorder.Code, http.StatusNotFound, "wrong status code")
+	assertion.Match("", recorder.Body.String(), "wrong body")
+}
+
+func TestAnalyticsWithSetValue(t *testing.T) {
+	etag := "11b9fdd2cfc348e9f1fbf2b774ca1625ea8bf5ed63a6e17fae6c2b0271895192"
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "", nil)
+	assets.Analyticsjs = "base url: __HOLMES_BASE_URL__"
+	PrepareAnalytics("https://example.org/baseurl")
+	assertion := assert.NewAssert(t)
+
+	Analytics(recorder, request)
+
+	assertion.Equal(recorder.Header().Get("Content-Type"), "application/javascript", "wrong content type")
+	assertion.Equal(recorder.Header().Get("Etag"), etag, "wrong etag code")
+	assertion.Equal(recorder.Code, http.StatusOK, "wrong status code")
+	assertion.Match("base url: https://example.org/baseurl", recorder.Body.String(), "wrong body")
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/justsocialapps/holmes/analytics"
+)
+
+var (
+	protocol     string
+	host         string
+	proxyPort    string
+	proxyPath    string
+	listenHost   string
+	listenPort   string
+	kafkaHost    string
+	logfileName  string
+	printVersion bool
+	anomyzeIP    bool
+)
+
+func init() {
+	flag.StringVar(&protocol, "protocol", "https", "The protocol used to serve Holmes resources ('http' or 'https')")
+	flag.StringVar(&host, "host", "localhost", "The host name used to reach Holmes")
+	flag.StringVar(&proxyPort, "proxyPort", "3001", "The TCP port for reaching Holmes if Holmes is operated behind a reverse proxy.")
+	flag.StringVar(&proxyPath, "proxyPath", "", "The base path for reaching Holmes if Holmes is operated behind a reverse proxy.")
+	flag.StringVar(&listenHost, "listenHost", "", "The host Holmes listens on.")
+	flag.StringVar(&listenPort, "listenPort", "3001", "The TCP port that Holmes listens on")
+	flag.StringVar(&kafkaHost, "kafkaHost", "localhost:9092", "The Kafka host to consume messages from")
+	flag.StringVar(&logfileName, "logfile", "", "The file to log messages to")
+	flag.BoolVar(&printVersion, "version", false, "Print Holmes version and exit")
+	flag.BoolVar(&anomyzeIP, "anonIP", false, "Sets the last octet (IPv4) or the last 80 bits (IPv6) of the client's IP address to 0 in the tracking object before submitting it to Kafka.")
+
+	flag.Parse()
+
+	var baseURL string
+
+	//only prepend the protocol when the user provided one
+	if protocol != "" {
+		baseURL = protocol + "://"
+	}
+
+	//only prepend the host when the user provided one
+	if host != "" {
+		baseURL = baseURL + host
+	}
+
+	//we only need to specify the port number when it's different than the
+	//standard 80/443.
+	if protocol != "" && !(protocol == "https" && proxyPort == "443") && !(protocol == "http" && proxyPort == "80") {
+		baseURL = baseURL + ":" + proxyPort
+	}
+
+	baseURL = baseURL + proxyPath
+
+	analytics.PrepareAnalytics(baseURL)
+}

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ var (
 	kafkaHost    string
 	logfileName  string
 	printVersion bool
-	anomyzeIP    bool
+	anonymizeIP  bool
 )
 
 func init() {
@@ -29,7 +29,7 @@ func init() {
 	flag.StringVar(&kafkaHost, "kafkaHost", "localhost:9092", "The Kafka host to consume messages from")
 	flag.StringVar(&logfileName, "logfile", "", "The file to log messages to")
 	flag.BoolVar(&printVersion, "version", false, "Print Holmes version and exit")
-	flag.BoolVar(&anomyzeIP, "anonIP", false, "Sets the last octet (IPv4) or the last 80 bits (IPv6) of the client's IP address to 0 in the tracking object before submitting it to Kafka.")
+	flag.BoolVar(&anonymizeIP, "anonIP", false, "Sets the last octet (IPv4) or the last 80 bits (IPv6) of the client's IP address to 0 in the tracking object before submitting it to Kafka.")
 
 	flag.Parse()
 

--- a/holmes.go
+++ b/holmes.go
@@ -62,7 +62,7 @@ func main() {
 	trackingChannel := make(chan *tracker.TrackingObject, 10)
 	trackingParams := tracker.TrackingParams{
 		TrackingChannel: trackingChannel,
-		AnonymizeIP:     anomyzeIP,
+		AnonymizeIP:     anonymizeIP,
 	}
 
 	go publisher.Publish(trackingChannel, kafkaHost, "tracking")

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -13,7 +13,7 @@ import (
 // Publish creates a Kafka producer and provides it with every TrackingObject
 // received via the given trackingChannel. If the producer cannot be started
 // the program exits.
-func Publish(trackingChannel <-chan *tracker.TrackingObject, kafkaHost *string, kafkaTopic string) {
+func Publish(trackingChannel <-chan *tracker.TrackingObject, kafkaHost string, kafkaTopic string) {
 	kafkaConfig := sarama.NewConfig()
 	kafkaConfig.Producer.Return.Errors = true
 	// If true, we have to read from the Successes channel or the producer
@@ -24,7 +24,7 @@ func Publish(trackingChannel <-chan *tracker.TrackingObject, kafkaHost *string, 
 	var producer sarama.AsyncProducer
 	err := justlib.Try(0, 10*time.Second, func() error {
 		var err error
-		producer, err = sarama.NewAsyncProducer([]string{*kafkaHost}, kafkaConfig)
+		producer, err = sarama.NewAsyncProducer([]string{kafkaHost}, kafkaConfig)
 		if err != nil {
 			log.Printf("Connection attempt to Kafka broker failed; trying again...\n")
 		}
@@ -33,7 +33,7 @@ func Publish(trackingChannel <-chan *tracker.TrackingObject, kafkaHost *string, 
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("Kafka producer up and running with broker %s", *kafkaHost)
+	log.Printf("Kafka producer up and running with broker %s", kafkaHost)
 
 	var object *tracker.TrackingObject
 	for {


### PR DESCRIPTION
do not replace the baseURL when this handler is called
- do it once before starting the server

moved config to separate file for better readability
- setup baseURL from there as it's not needed anywhere else

added etag support for the analytics.js
- return 304 if etag is matched

Change-Id: I95ea64405a34fcb962ec9fc16724b3cfec77ec5d