### PR TITLE
Build binary for linux/arm64

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -23,6 +23,7 @@ GOOS=windows GOARCH=amd64 go build -o holmes_${VERSION}_windows_amd64.exe
 GOOS=windows GOARCH=386 go build -o holmes_${VERSION}_windows_386.exe
 GOOS=linux GOARCH=386 go build -o holmes_${VERSION}_linux_386
 GOOS=linux GOARCH=amd64 go build -o holmes_${VERSION}_linux_amd64
+GOOS=linux GOARCH=arm64 go build -o holmes_${VERSION}_linux_arm64
 
 echo Uploading release files...
 for i in holmes_${VERSION}_* ; do


### PR DESCRIPTION
In addition to the currently supported system architectures, build a
binary for linux with arm64.